### PR TITLE
ci: builder pipeline analog

### DIFF
--- a/.builder/pipelines/maven.yml
+++ b/.builder/pipelines/maven.yml
@@ -1,0 +1,15 @@
+name: Java CI with Maven
+on: [push, manual]
+push:
+  branches: [main]
+jobs:
+  build:
+    image: maven:3.9-eclipse-temurin-17
+    cache:
+      key: m2-spring-boot-playground
+      paths: [.m2/repository]
+    steps:
+      - name: Checkout
+        run: git clone --depth 1 https://github.com/alexmond/spring-boot-playground.git .
+      - name: Build with Maven
+        run: mvn -B package --file pom.xml -Dmaven.repo.local=.m2/repository


### PR DESCRIPTION
Adds a builder pipeline under `.builder/pipelines/` mirroring the existing GitHub Actions Maven workflow, so the same build can run on builder (GitLab-style YAML, AI-aware CI/CD).

- `.builder/pipelines/maven.yml` — analog of `.github/workflows/maven.yml`: triggers on push to `main` (plus manual), checks out the repo, and runs `mvn -B package` in a `maven:3.9-eclipse-temurin-17` image with a cached local `.m2` repository.

Additive and inert: the GitHub Actions workflow is untouched and keeps running. No secrets, no deploys.

Minor translation notes:
- Build runs in a Maven image (`maven:3.9-eclipse-temurin-17`) since the repo has no `./mvnw` wrapper; this preserves the JDK 17 + Maven combination from the original.
- The PR `pull_request` trigger maps to push/manual, as builder triggers on branch pushes rather than PR events.