### PR TITLE
Upgrade to Spring Boot 4.0.7 and bump third-party dependencies

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -21,10 +21,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - name: Set up JDK 17
+      - name: Set up JDK 21
         uses: actions/setup-java@v4
         with:
-          java-version: '17'
+          java-version: '21'
           distribution: 'temurin'
           cache: maven
       - name: Build with Maven

--- a/pom.xml
+++ b/pom.xml
@@ -29,13 +29,13 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.5.8</version>
+        <version>4.0.7</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
     <properties>
-        <spring-boot-admin.version>3.5.5</spring-boot-admin.version>
-        <spring-cloud.version>2025.0.0</spring-cloud.version>
-        <spring-boot-config-json-schema.version>1.0.8</spring-boot-config-json-schema.version>
+        <spring-boot-admin.version>4.0.4</spring-boot-admin.version>
+        <spring-cloud.version>2025.1.2</spring-cloud.version>
+        <spring-boot-config-json-schema.version>4.0.7.1</spring-boot-config-json-schema.version>
     </properties>
     <dependencyManagement>
         <dependencies>

--- a/spring-boot-admin-server/pom.xml
+++ b/spring-boot-admin-server/pom.xml
@@ -28,7 +28,7 @@
     </developers>
     <properties>
         <java.version>17</java.version>
-        <spring-cloud.version>2025.0.0</spring-cloud.version>
+        <spring-cloud.version>2025.1.2</spring-cloud.version>
     </properties>
     <dependencyManagement>
         <dependencies>

--- a/spring-boot-ai-samples/spring-boot-ai-sample/pom.xml
+++ b/spring-boot-ai-samples/spring-boot-ai-sample/pom.xml
@@ -16,7 +16,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <spring-ai.version>1.0.0-M3</spring-ai.version>
+        <spring-ai.version>2.0.0</spring-ai.version>
     </properties>
 
     <dependencies>
@@ -44,7 +44,7 @@
         <!-- Spring AI -->
         <dependency>
             <groupId>org.springframework.ai</groupId>
-            <artifactId>spring-ai-openai-spring-boot-starter</artifactId>
+            <artifactId>spring-ai-starter-model-openai</artifactId>
         </dependency>
 
         <!-- Database -->

--- a/spring-boot-data-jpa-flyway/pom.xml
+++ b/spring-boot-data-jpa-flyway/pom.xml
@@ -65,7 +65,7 @@
         <dependency>
             <groupId>org.alexmond</groupId>
             <artifactId>spring-boot-config-json-schema-starter</artifactId>
-            <version>0.0.2</version>
+            <version>${spring-boot-config-json-schema.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/spring-boot-k8-parent/spring-boot-kubernetes-client/src/main/java/org/alexmond/sample/k8/controller/KuberClientRest.java
+++ b/spring-boot-k8-parent/spring-boot-kubernetes-client/src/main/java/org/alexmond/sample/k8/controller/KuberClientRest.java
@@ -33,7 +33,7 @@ public class KuberClientRest {
     @GetMapping("/pods")
     public ResponseEntity<List<String>> getPods() {
         try {
-            V1PodList podList = api().listPodForAllNamespaces(null, null, null, null, null, null, null, null, null, null, null);
+            V1PodList podList = api().listPodForAllNamespaces().execute();
             List<String> pods = podList.getItems().stream()
                     .map(pod -> pod.getMetadata().getName())
                     .collect(Collectors.toList());
@@ -47,7 +47,7 @@ public class KuberClientRest {
     @GetMapping("/pods/{namespace}")
     public ResponseEntity<List<String>> getPodsByNamespace(@PathVariable String namespace) {
         try {
-            V1PodList podList = api().listNamespacedPod(namespace, null, null, null, null, null, null, null, null, null, null, null);
+            V1PodList podList = api().listNamespacedPod(namespace).execute();
             List<String> pods = podList.getItems().stream()
                     .map(pod -> pod.getMetadata().getName())
                     .collect(Collectors.toList());
@@ -61,7 +61,7 @@ public class KuberClientRest {
     @GetMapping("/pods/details/{name}")
     public ResponseEntity<V1Pod> getPodByName(@PathVariable String name) {
         try {
-            V1Pod pod = api().listPodForAllNamespaces(null, null, null, null, null, null, null, null, null, null, null)
+            V1Pod pod = api().listPodForAllNamespaces().execute()
                     .getItems().stream()
                     .filter(p -> name.equals(p.getMetadata().getName()))
                     .findFirst()
@@ -76,7 +76,7 @@ public class KuberClientRest {
     @GetMapping("/pods/count")
     public ResponseEntity<Integer> getPodCount() {
         try {
-            int count = api().listPodForAllNamespaces(null, null, null, null, null, null, null, null, null, null, null)
+            int count = api().listPodForAllNamespaces().execute()
                     .getItems()
                     .size();
             return ResponseEntity.ok(count);
@@ -89,7 +89,7 @@ public class KuberClientRest {
     @GetMapping("/namespaces")
     public ResponseEntity<List<String>> getNamespaces() {
         try {
-            V1NamespaceList namespaceList = api().listNamespace(null, null, null, null, null, null, null, null, null, null, null);
+            V1NamespaceList namespaceList = api().listNamespace().execute();
             List<String> namespaces = namespaceList.getItems().stream()
                     .map(namespace -> namespace.getMetadata().getName())
                     .collect(Collectors.toList());

--- a/spring-boot-openapi-parent/spring-boot-openapi-client/pom.xml
+++ b/spring-boot-openapi-parent/spring-boot-openapi-client/pom.xml
@@ -30,7 +30,7 @@
                 <groupId>org.openapitools</groupId>
                 <artifactId>openapi-generator-maven-plugin</artifactId>
                 <!-- RELEASE_VERSION -->
-                <version>7.14.0</version>
+                <version>7.23.0</version>
                 <!-- /RELEASE_VERSION -->
                 <!--                <dependencies>-->
                 <!--                    <dependency>-->
@@ -78,10 +78,10 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.8.1</version>
+                <version>3.15.0</version>
                 <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
+                    <source>${java.version}</source>
+                    <target>${java.version}</target>
                     <proc>none</proc>
                 </configuration>
             </plugin>

--- a/spring-boot-openapi-parent/spring-boot-openapi/pom.xml
+++ b/spring-boot-openapi-parent/spring-boot-openapi/pom.xml
@@ -41,7 +41,7 @@
         <dependency>
             <groupId>org.springdoc</groupId>
             <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
-            <version>2.8.9</version>
+            <version>3.0.3</version>
         </dependency>
         <dependency>
             <groupId>org.projectlombok</groupId>
@@ -51,6 +51,12 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <!-- Boot 4 modularized the MVC test slice (@WebMvcTest / @AutoConfigureMockMvc) -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-webmvc-test</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/spring-boot-openapi-parent/spring-boot-openapi/src/test/java/org/alexmond/sample/openapi/SimpleBootRestSampleApplicationTests.java
+++ b/spring-boot-openapi-parent/spring-boot-openapi/src/test/java/org/alexmond/sample/openapi/SimpleBootRestSampleApplicationTests.java
@@ -2,7 +2,7 @@ package org.alexmond.sample.openapi;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.web.servlet.MockMvc;
 

--- a/spring-boot-security-parent/oauth2-authorization-server/pom.xml
+++ b/spring-boot-security-parent/oauth2-authorization-server/pom.xml
@@ -36,11 +36,29 @@
             <artifactId>spring-security-oauth2-authorization-server</artifactId>
         </dependency>
 
-        <!-- JWT and JOSE -->
+        <!-- JWT and JOSE (not managed by the Boot BOM; Spring Security 7.0.x uses 10.x) -->
         <dependency>
             <groupId>com.nimbusds</groupId>
             <artifactId>nimbus-jose-jwt</artifactId>
-            <version>9.37</version>
+            <version>10.9.1</version>
+        </dependency>
+
+        <!-- Boot 4 moved RestTemplateBuilder into spring-boot-restclient -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-restclient</artifactId>
+        </dependency>
+
+        <!--
+          spring-security-oauth2-authorization-server excludes commons-logging from its
+          spring-core, which wins dependency mediation and leaves the JCL API absent
+          (NoClassDefFoundError: org/apache/commons/logging/LogFactory). Restore it the
+          Spring Boot way: the SLF4J JCL bridge, which supplies the commons-logging API
+          but routes it through SLF4J/Logback. Version managed by Boot.
+        -->
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>jcl-over-slf4j</artifactId>
         </dependency>
 
         <!-- Spring Boot Data JPA -->
@@ -73,13 +91,19 @@
         <dependency>
             <groupId>org.springdoc</groupId>
             <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
-            <version>2.0.4</version>
+            <version>3.0.3</version>
         </dependency>
 
         <!-- Testing -->
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <!-- Boot 4 modularized the MVC test slice (@WebMvcTest / @AutoConfigureMockMvc) -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-webmvc-test</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/spring-boot-security-parent/oauth2-authorization-server/src/main/java/org/alexmond/sample/oauth2/client/OAuth2TestClient.java
+++ b/spring-boot-security-parent/oauth2-authorization-server/src/main/java/org/alexmond/sample/oauth2/client/OAuth2TestClient.java
@@ -2,7 +2,7 @@ package org.alexmond.sample.oauth2.client;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.boot.restclient.RestTemplateBuilder;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Component;

--- a/spring-boot-security-parent/oauth2-authorization-server/src/main/java/org/alexmond/sample/oauth2/config/OAuth2AuthorizationServerConfig.java
+++ b/spring-boot-security-parent/oauth2-authorization-server/src/main/java/org/alexmond/sample/oauth2/config/OAuth2AuthorizationServerConfig.java
@@ -24,8 +24,8 @@ import org.springframework.security.oauth2.jwt.JwtDecoder;
 import org.springframework.security.oauth2.server.authorization.client.InMemoryRegisteredClientRepository;
 import org.springframework.security.oauth2.server.authorization.client.RegisteredClient;
 import org.springframework.security.oauth2.server.authorization.client.RegisteredClientRepository;
-import org.springframework.security.oauth2.server.authorization.config.annotation.web.configuration.OAuth2AuthorizationServerConfiguration;
-import org.springframework.security.oauth2.server.authorization.config.annotation.web.configurers.OAuth2AuthorizationServerConfigurer;
+import org.springframework.security.config.annotation.web.configuration.OAuth2AuthorizationServerConfiguration;
+import org.springframework.security.config.annotation.web.configurers.oauth2.server.authorization.OAuth2AuthorizationServerConfigurer;
 import org.springframework.security.oauth2.server.authorization.settings.AuthorizationServerSettings;
 import org.springframework.security.oauth2.server.authorization.settings.ClientSettings;
 import org.springframework.security.oauth2.server.authorization.settings.TokenSettings;
@@ -33,6 +33,7 @@ import org.springframework.security.provisioning.InMemoryUserDetailsManager;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.LoginUrlAuthenticationEntryPoint;
 import org.springframework.security.web.util.matcher.MediaTypeRequestMatcher;
+import org.springframework.security.web.util.matcher.RequestMatcher;
 
 import java.security.KeyPair;
 import java.security.KeyPairGenerator;
@@ -48,12 +49,18 @@ public class OAuth2AuthorizationServerConfig {
     @Bean
     @Order(1)
     public SecurityFilterChain authorizationServerSecurityFilterChain(HttpSecurity http) throws Exception {
-        OAuth2AuthorizationServerConfiguration.applyDefaultSecurity(http);
+        OAuth2AuthorizationServerConfigurer authorizationServerConfigurer =
+                new OAuth2AuthorizationServerConfigurer();
+        RequestMatcher endpointsMatcher = authorizationServerConfigurer.getEndpointsMatcher();
 
-        http.getConfigurer(OAuth2AuthorizationServerConfigurer.class)
-                .oidc(Customizer.withDefaults());
-
-        http.exceptionHandling((exceptions) -> exceptions
+        http
+                .securityMatcher(endpointsMatcher)
+                .with(authorizationServerConfigurer, (authorizationServer) ->
+                        authorizationServer.oidc(Customizer.withDefaults())
+                )
+                .authorizeHttpRequests((authorize) -> authorize.anyRequest().authenticated())
+                .csrf((csrf) -> csrf.ignoringRequestMatchers(endpointsMatcher))
+                .exceptionHandling((exceptions) -> exceptions
                         .defaultAuthenticationEntryPointFor(
                                 new LoginUrlAuthenticationEntryPoint("/login"),
                                 new MediaTypeRequestMatcher(MediaType.TEXT_HTML)

--- a/spring-boot-security-parent/oauth2-authorization-server/src/test/java/org/alexmond/sample/oauth2/OAuth2ServerApplicationTests.java
+++ b/spring-boot-security-parent/oauth2-authorization-server/src/test/java/org/alexmond/sample/oauth2/OAuth2ServerApplicationTests.java
@@ -2,7 +2,7 @@ package org.alexmond.sample.oauth2;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;

--- a/spring-boot-security-parent/spring-boot-custom-auth-server/pom.xml
+++ b/spring-boot-security-parent/spring-boot-custom-auth-server/pom.xml
@@ -23,11 +23,17 @@
         <dependency>
             <groupId>org.springdoc</groupId>
             <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
-            <version>2.8.9</version>
+            <version>3.0.3</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <!-- Boot 4 modularized the MVC test slice (@WebMvcTest / @AutoConfigureMockMvc) -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-webmvc-test</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -48,12 +54,12 @@
         <dependency>
             <groupId>org.webjars</groupId>
             <artifactId>bootstrap</artifactId>
-            <version>5.3.3</version>
+            <version>5.3.8</version>
         </dependency>
         <dependency>
             <groupId>org.webjars</groupId>
             <artifactId>font-awesome</artifactId>
-            <version>6.5.1</version>
+            <version>7.2.0</version>
         </dependency>
         <dependency>
             <groupId>org.webjars</groupId>

--- a/spring-boot-security-parent/spring-boot-custom-auth-server/src/test/java/org/alexmond/sample/auth/controller/AuthControllerTest.java
+++ b/spring-boot-security-parent/spring-boot-custom-auth-server/src/test/java/org/alexmond/sample/auth/controller/AuthControllerTest.java
@@ -3,7 +3,7 @@ package org.alexmond.sample.auth.controller;
 import org.alexmond.sample.auth.service.UserService;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;

--- a/spring-boot-security-parent/spring-boot-form-auth-app/pom.xml
+++ b/spring-boot-security-parent/spring-boot-form-auth-app/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.3.0</version>
+        <version>4.0.7</version>
         <relativePath/>
     </parent>
 

--- a/spring-boot-security-parent/spring-boot-form-auth-app/src/test/java/org/alexmond/sample/formauth/FormAuthApplicationTests.java
+++ b/spring-boot-security-parent/spring-boot-form-auth-app/src/test/java/org/alexmond/sample/formauth/FormAuthApplicationTests.java
@@ -1,23 +1,35 @@
 package org.alexmond.sample.formauth;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
 
-import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @SpringBootTest
-@AutoConfigureMockMvc
 class FormAuthApplicationTests {
 
     @Autowired
+    private WebApplicationContext context;
+
     private MockMvc mockMvc;
+
+    // Boot 4 removed the auto-applied MockMvc Spring Security integration
+    // (former MockMvcSecurityConfiguration), so apply springSecurity() explicitly
+    // for @WithMockUser to take effect.
+    @BeforeEach
+    void setUp() {
+        mockMvc = MockMvcBuilders.webAppContextSetup(context)
+                .apply(springSecurity())
+                .build();
+    }
 
     @Test
     void contextLoads() {

--- a/spring-boot-thymeleaf/spring-boot-thymeleaf-sample/pom.xml
+++ b/spring-boot-thymeleaf/spring-boot-thymeleaf-sample/pom.xml
@@ -44,12 +44,12 @@
         <dependency>
             <groupId>org.webjars</groupId>
             <artifactId>bootstrap</artifactId>
-            <version>5.3.3</version>
+            <version>5.3.8</version>
         </dependency>
         <dependency>
             <groupId>org.webjars</groupId>
             <artifactId>font-awesome</artifactId>
-            <version>6.5.1</version>
+            <version>7.2.0</version>
         </dependency>
         <dependency>
             <groupId>org.webjars</groupId>


### PR DESCRIPTION
Moves the whole reactor from Spring Boot **3.5.8 → 4.0.7** (Spring Framework 7, Spring Security 7) and upgrades all non-Boot-managed dependencies to their Boot-4-compatible releases.

## Dependency bumps
| Dep | From | To |
|---|---|---|
| spring-boot parent | 3.5.8 | 4.0.7 (form-auth-app 3.3.0 → 4.0.7) |
| spring-cloud | 2025.0.0 | 2025.1.2 (Boot 4.0 train) |
| spring-boot-admin | 3.5.5 | 4.0.4 |
| config-json-schema | 1.0.8 / 0.0.2 | 4.0.7.1 (Boot-aligned build) |
| spring-ai | 1.0.0-M3 | 2.0.0 (+ starter rename) |
| springdoc-openapi | 2.8.9 / 2.0.4 | 3.0.3 |
| openapi-generator / compiler plugin | 7.14.0 / 3.8.1 | 7.23.0 / 3.15.0 |
| webjars bootstrap / font-awesome | 5.3.3 / 6.5.1 | 5.3.8 / 7.2.0 |
| nimbus-jose-jwt | 9.37 | 10.9.1 (no longer in the Boot BOM) |

## Migration fixes (Boot 4 / Framework 7 / Security 7)
- Moved test-slice imports to `spring-boot-webmvc-test` (`@WebMvcTest` / `@AutoConfigureMockMvc` now under `org.springframework.boot.webmvc.test.autoconfigure`); added that dependency where used.
- `RestTemplateBuilder` relocated to `org.springframework.boot.restclient`; added the `spring-boot-restclient` dependency.
- OAuth2 authorization-server config classes merged into Spring Security core packages; rewrote the filter chain to the current `OAuth2AuthorizationServerConfigurer` + `http.with(...)` style (`applyDefaultSecurity` was removed).
- Kubernetes `client-java` 26 (via spring-cloud 2025.1) switched to the fluent request builders: `listPodForAllNamespaces().execute()`, etc.
- `spring-security-oauth2-authorization-server` excludes `commons-logging` and Boot 4's `starter-logging` no longer ships a JCL bridge, so route the JCL API through SLF4J with `org.slf4j:jcl-over-slf4j` (fixes `NoClassDefFoundError: org/apache/commons/logging/LogFactory` at startup).
- Boot 4 dropped the auto-applied MockMvc Spring Security integration, so `FormAuthApplicationTests` builds MockMvc with `SecurityMockMvcConfigurers.springSecurity()` for `@WithMockUser` to take effect.

## Test status
Full reactor compiles; all modules' tests pass **except three that were already failing on 3.5.8 before this change** (verified against a stashed baseline) and are left untouched as pre-existing, out-of-scope:
- `oauth2-authorization-server` auth tests — hit `/userinfo` expecting mock auth but the endpoint needs a real bearer token.
- `spring-boot-kubernetes-client` / `spring-boot-fabric8-client` — test class sits in the wrong package (`org.alexmond.sample.config` vs app `org.alexmond.sample.k8`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)